### PR TITLE
Return result of 'fill' method

### DIFF
--- a/src/SimpleRepeatable.php
+++ b/src/SimpleRepeatable.php
@@ -98,7 +98,7 @@ class SimpleRepeatable extends Field
             Validator::make([$this->attribute => $value], $rules)->validate();
         }
 
-        parent::fill($request, $model);
+        return parent::fill($request, $model);
     }
 
     protected function getFormattedRules(NovaRequest $request)


### PR DESCRIPTION
The parent implementation of `fill` returns the value.

If the value is a valid callable than it is executed _after_ the model is saved. This is helpful when dealing with complex relationships.